### PR TITLE
ScanResult shall detect ERROR responses

### DIFF
--- a/src/main/java/com/philvarner/clamavj/ScanResult.java
+++ b/src/main/java/com/philvarner/clamavj/ScanResult.java
@@ -12,9 +12,9 @@ public class ScanResult {
     public static final String STREAM_PREFIX = "stream: ";
     public static final String RESPONSE_OK = "stream: OK";
     public static final String FOUND_SUFFIX = "FOUND";
+    public static final String ERROR_SUFFIX = "ERROR";
 
     public static final String RESPONSE_SIZE_EXCEEDED = "INSTREAM size limit exceeded. ERROR";
-    public static final String RESPONSE_ERROR_WRITING_FILE = "Error writing to temporary file. ERROR";
 
     public ScanResult(String result) {
         setResult(result);
@@ -46,9 +46,7 @@ public class ScanResult {
             setStatus(Status.PASSED);
         } else if (result.endsWith(FOUND_SUFFIX)) {
             setSignature(result.substring(STREAM_PREFIX.length(), result.lastIndexOf(FOUND_SUFFIX) - 1));
-        } else if (RESPONSE_SIZE_EXCEEDED.equals(result)) {
-            setStatus(Status.ERROR);
-        } else if (RESPONSE_ERROR_WRITING_FILE.equals(result)) {
+        } else if (result.endsWith(ERROR_SUFFIX)) {
             setStatus(Status.ERROR);
         }
 

--- a/src/test/java/com/philvarner/clamavj/test/ScanResultTestCase.java
+++ b/src/test/java/com/philvarner/clamavj/test/ScanResultTestCase.java
@@ -1,0 +1,26 @@
+package com.philvarner.clamavj.test;
+
+import com.philvarner.clamavj.ScanResult;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class ScanResultTestCase {
+
+	/**
+	 * Detect scan-failures correctly, as reported by ClamAV.
+	 * 
+	 * ClamAV reports errors by using a suffix of "ERROR". See
+	 * https://github.com/vrtadmin/clamav-devel/blob/79efd61b432f71b3f420d2582c352f15a81099cf/clamd/session.c#L169
+	 * 
+	 * To reproduce, set <code>TemporaryDirectory</code> in clamd.conf to
+	 * directory with limited diskspace, then attempt to scan a file larger
+	 * than the available space.
+	 */
+	@Test
+	public void testErrorDetection() {
+		String response = "Error writing to temporary file ERROR";
+		ScanResult scanResult = new ScanResult(response);
+		
+		assertEquals(ScanResult.Status.ERROR, scanResult.getStatus());
+	}
+}


### PR DESCRIPTION
ClamAV indicates errors encountered during a transfer by adding a suffix of "ERROR" to the response message. The `ScanResult` was not detecting this properly.